### PR TITLE
Small fixes for SignificanceMetrics.hxx and LoadEvents.hxx

### DIFF
--- a/studies/h2mumu/LoadEvents.hxx
+++ b/studies/h2mumu/LoadEvents.hxx
@@ -10,11 +10,15 @@
 // _______________________Includes_______________________________________//
 ///////////////////////////////////////////////////////////////////////////
 
-#include "TNtuple.h"
-#include "TFile.h"
-#include <sstream>
+#include <algorithm>
 #include <fstream>
 #include <map>
+#include <sstream>
+
+#include "TFile.h"
+#include "TNtuple.h"
+
+#include "Event.h"
 
 //////////////////////////////////////////////////////////////////////////
 // ______________________Load Info From_CSV____________________________//


### PR DESCRIPTION
The changes to SignificanceMetrics.hxx enable ROOT to load the header file without complaining, while the changes to LoadEvents.hxx are necessary for ROOT to generate a dictionary when dynamically loading the functions defined in the header. These additions allow ROOT to expose the C++ objects and functions for use in Python.

This replaces PR #1.

Sorry about merging these directly into the binned_categorizer branch, since that is essentially our master branch and I should stay synced to you as the central repository. I won't make this mistake again.